### PR TITLE
Improve the init command

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: whool-init
+  name: init pyproject.toml with whool
+  entry: whool init exit-non-zero-on-changes
+  language: python
+  always_run: true
+  pass_filenames: false

--- a/news/10.fature
+++ b/news/10.fature
@@ -1,0 +1,1 @@
+Add pre-commit hook to initialize `pyproject.toml`.

--- a/src/whool/cli.py
+++ b/src/whool/cli.py
@@ -24,11 +24,19 @@ def main() -> None:
     )
     subparsers = ap.add_subparsers(title="subcommands", dest="subcmd")
 
-    subparsers.add_parser(
+    init_ap = subparsers.add_parser(
         "init",
-        help="Initialize pyproject.toml in addon_dir with the whool build-system.",
+        help=(
+            "Initialize pyproject.toml files with the whool build-system. "
+            "This is done in the current directory if it is an addon, "
+            "else in immediate subdirectories that are addons."
+        ),
     )
-    # TODO init --git-commit, --git-add
+    init_ap.add_argument(
+        "--exit-non-zero-on-changes",
+        action="store_true",
+        help="Exit with non-zero status if any changes were made.",
+    )
 
     args = ap.parse_args(sys.argv[1:])
     if args.verbose >= 2:
@@ -40,7 +48,9 @@ def main() -> None:
     logging.basicConfig(level=log_level)
 
     if args.subcmd == "init":
-        init(Path.cwd())
+        modified_files = init(Path.cwd())
+        if args.exit_non_zero_on_changes and modified_files:
+            sys.exit(1)
     else:
         ap.print_help()
         sys.exit(1)

--- a/src/whool/init.py
+++ b/src/whool/init.py
@@ -2,6 +2,8 @@ import logging
 from pathlib import Path
 from typing import Sequence
 
+from manifestoo_core.addon import is_addon_dir
+
 from .compat import tomllib
 
 _logger = logging.getLogger(__name__)
@@ -14,39 +16,34 @@ build-backend = "whool.buildapi"
 
 
 def init_addon_dir(addon_dir: Path) -> bool:
-    if not addon_dir.joinpath("__manifest__.py").is_file():
-        return False
+    modified = False
     pyproject_toml_path = addon_dir / "pyproject.toml"
     if not pyproject_toml_path.exists():
+        # create pyproject.toml
         with open(pyproject_toml_path, "wb") as f:
             f.write(BUILD_SYSTEM_TOML)
+        modified = True
     else:
         with open(pyproject_toml_path, "rb") as f:
             pyproject_toml = tomllib.load(f)
-        if "build-system" in pyproject_toml:
-            if (
-                pyproject_toml.get("build-system", {}).get("build-backend")
-                != "whool.buildapi"
-            ):
-                _logger.debug(
-                    f"Did not initialize Whool build-system in {pyproject_toml_path} "
-                    f"because another one is already defined.",
-                )
-                return False
-        else:
+        if "build-system" not in pyproject_toml:
+            # no build-system in existing pyproject.toml, add one
             with open(pyproject_toml_path, "ab") as f:
                 f.write(b"\n")
                 f.write(BUILD_SYSTEM_TOML)
-    return True
+            modified = True
+    return modified
 
 
 def init(dir: Path) -> Sequence[Path]:
     res = []
-    if init_addon_dir(dir):
-        res.append(dir)
+    if is_addon_dir(dir):
+        if init_addon_dir(dir):
+            res.append(dir)
     else:
         for subdir in dir.iterdir():
             if subdir.is_dir():
-                if init_addon_dir(subdir):
-                    res.append(subdir)
+                if is_addon_dir(subdir):
+                    if init_addon_dir(subdir):
+                        res.append(subdir)
     return res


### PR DESCRIPTION
Improve documentation of the init command.
Add and option to exit with non-zero status in case any pyproject.toml is created or modified.