### PR TITLE
feat(init): accept dir argument, not always cwd

### DIFF
--- a/news/21.feature
+++ b/news/21.feature
@@ -1,0 +1,1 @@
+whool init now accepts a directory argument

--- a/src/whool/cli.py
+++ b/src/whool/cli.py
@@ -40,6 +40,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         action="store_true",
         help="Exit with non-zero status if any changes were made.",
     )
+    init_ap.add_argument(
+        "dir",
+        type=Path,
+        nargs="?",
+        default=Path.cwd(),
+        help="Addon(s) directory to initialize (default: current directory).",
+    )
 
     args = ap.parse_args(argv)
     if args.verbose >= 2:
@@ -51,10 +58,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     logging.basicConfig(level=log_level)
 
     if args.subcmd == "init":
-        modified_files = init(Path.cwd())
+        modified_files = init(args.dir)
         if args.exit_non_zero_on_changes and modified_files:
             modified_str = ", ".join(
-                str(p.relative_to(Path.cwd())) for p in modified_files
+                str(p.relative_to(args.dir)) for p in modified_files
             )
             sys.stderr.write(
                 f"pyproject.toml was generated or modified in {modified_str}\n"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -78,3 +78,10 @@ def test_init_cli_nonzero_exit(
     assert pyproject_toml_path.exists()
     captured = capsys.readouterr()
     assert captured.err == "pyproject.toml was generated or modified in .\n"
+
+
+def test_init_cli_no_cwd(addon1: Path) -> None:
+    pyproject_toml_path = addon1 / "pyproject.toml"
+    assert not pyproject_toml_path.exists()
+    assert main(["init", "--exit-non-zero-on-changes", str(addon1)]) == 1
+    assert pyproject_toml_path.exists()


### PR DESCRIPTION
This will help integrating with pre-commit on nonstandard repo structures, such as Doodba ones.

@moduon MT-1075