### PR TITLE
fix: let it work without Git when it's not really needed

### DIFF
--- a/news/23.bugfix
+++ b/news/23.bugfix
@@ -1,0 +1,1 @@
+Let it work without Git when it's not required

--- a/src/whool/buildapi.py
+++ b/src/whool/buildapi.py
@@ -44,7 +44,7 @@ def _scm_ls_files(addon_dir: Path) -> List[str]:
             .strip()
             .split("\n")
         )
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
         raise NoScmFound() from e
 
 

--- a/tests/test_build_wheel.py
+++ b/tests/test_build_wheel.py
@@ -2,6 +2,9 @@ import os
 from pathlib import Path
 from zipfile import ZipFile
 
+import pytest
+from manifestoo_core.git_postversion import POST_VERSION_STRATEGY_NONE
+
 from whool.buildapi import build_wheel
 from whool.init import init_addon_dir
 
@@ -37,3 +40,15 @@ def test_build_wheel_without_scm(tmp_path: Path) -> None:
             names = zf.namelist()
             assert "odoo/addons/addon1/__manifest__.py" in names
             assert "odoo/addons/addon1/pyproject.toml" not in names
+
+
+def test_build_wheel_git_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Make sure we can't find git executable
+    monkeypatch.setenv("PATH", "/foo")
+    # Override strategy so Git is not needed
+    monkeypatch.setenv(
+        "WHOOL_POST_VERSION_STRATEGY_OVERRIDE", POST_VERSION_STRATEGY_NONE
+    )
+    test_build_wheel_without_scm(tmp_path)


### PR DESCRIPTION
When building from non-git-controlled sources, whool sill failed if Git wasn't available.

@moduon MT-1075